### PR TITLE
fix: Move MySQL service to host due to container instability

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,30 +12,11 @@ services:
       - 8080:8080
     env_file:
       - .env
-    depends_on:
-      - mysql
 
   aircraft_scraper:
     image: computers33333/airaccidentdata-aircraft_scraper:latest
     env_file:
       - .env
-    depends_on:
-      - mysql
-
-  mysql:
-    image: mysql:latest
-    healthcheck:
-      test: ['CMD-SHELL', 'mysqladmin ping -h localhost -uroot -p$${MYSQL_ROOT_PASSWORD}']
-      interval: 10s
-      timeout: 5s
-      retries: 5
-    ports:
-      - 3306:3306
-    volumes:
-      - mysql_airaccidentdata_prod:/var/lib/mysql
-    env_file:
-      - .env
-    restart: always
 
   nginx:
     image: nginx:latest
@@ -48,7 +29,3 @@ services:
     depends_on:
       - frontend
       - backend
-
-volumes:
-  mysql_airaccidentdata_prod:
-    driver: local


### PR DESCRIPTION
## Description

The MySQL service, running in a Docker container, was frequently shutting down due to resource limitations on the VPS. To mitigate this issue, the MySQL service has been moved to run directly on the host machine instead of within a Docker container. This change is expected to improve the stability and performance of the service.

## Changes Made

- Removed MySQL service from Docker Compose configuration.
- Updated `.env` file to use host IP address for MySQL connection.
- Modified initialization script to connect to MySQL on the host.
- Ensured necessary MySQL user privileges are set for remote access.

## Testing

- Verified MySQL connection from Docker containers to the host.
- Tested database initialization script for successful execution.
- Checked the stability and uptime of the MySQL service on the host.
- Ensured all application functionalities dependent on MySQL work correctly.

## Checklist

- [x] My code follows the style guidelines and best practices of this project.
- [x] I have reviewed and tested the code changes thoroughly.
- [x] I have added or updated unit tests to cover the modified code and ensure its correctness.
- [x] All existing unit tests pass with the changes.
- [x] The changes do not introduce any known security vulnerabilities.
- [x] I have considered the impact of these changes on performance, scalability, and maintainability.
- [x] The documentation has been updated to reflect the changes introduced (if applicable).
